### PR TITLE
feat: use capital letter for public export

### DIFF
--- a/dev/mod.nix
+++ b/dev/mod.nix
@@ -1,4 +1,4 @@
 {
-  pub_pkgs = mod.pkgs;
-  pub_shell = mod.shell;
+  Pkgs = mod.pkgs;
+  Shell = mod.shell;
 }

--- a/std/file/mod.nix
+++ b/std/file/mod.nix
@@ -1,1 +1,1 @@
-{ pub_parse = mod.parse; }
+{ Parse = mod.parse; }

--- a/std/mod.nix
+++ b/std/mod.nix
@@ -1,6 +1,7 @@
 {
-  pub_fix = mod.fix;
-  pub_file = mod.file;
-  pub_set = mod.set;
-  pub_path = mod.path;
+  Fix = mod.fix;
+  File = mod.file;
+  Set = mod.set;
+  Path = mod.path;
+  String = mod.string;
 }

--- a/std/path/mod.nix
+++ b/std/path/mod.nix
@@ -1,1 +1,1 @@
-{ pub_strToPath = mod.strToPath; }
+{ StrToPath = mod.strToPath; }

--- a/std/set/mod.nix
+++ b/std/set/mod.nix
@@ -1,4 +1,4 @@
 {
-  pub_cond = mod.cond;
-  pub_filterMap = mod.filterMap;
+  Cond = mod.cond;
+  FilterMap = mod.filterMap;
 }

--- a/std/string/mod.nix
+++ b/std/string/mod.nix
@@ -1,0 +1,10 @@
+{
+  upperChars = mod.stringToChars "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  lowerChars = mod.stringToChars "abcdefghijklmnopqrstuvwxyz";
+
+  stringToChars = s: std.genList (p: std.substring p 1 s) (std.stringLength s);
+
+  ToLower = std.replaceStrings mod.upperChars mod.lowerChars;
+
+  ToLowerCase = mod.toLowerCase;
+}

--- a/std/string/toLowerCase.nix
+++ b/std/string/toLowerCase.nix
@@ -1,0 +1,6 @@
+s:
+let
+  head = std.substring 0 1 s;
+  tail = std.substring 1 (-1) s;
+in
+"${mod.toLower or mod.ToLower head}${tail}"

--- a/test/bld/buzz/fuzz/mod.nix
+++ b/test/bld/buzz/fuzz/mod.nix
@@ -1,5 +1,5 @@
 {
   foo = 1;
-  pub_bar = pre.bar + 2;
+  Bar = pre.bar + 2;
   baz = mod.bar + 4;
 }

--- a/test/bld/buzz/mod.nix
+++ b/test/bld/buzz/mod.nix
@@ -2,5 +2,5 @@
   foo = 1;
   bar = pre.foo + 2;
   baz = mod.bar + 4;
-  pub_fuzz = mod.fuzz;
+  Fuzz = mod.fuzz;
 }

--- a/test/bld/mod.nix
+++ b/test/bld/mod.nix
@@ -1,10 +1,10 @@
 {
-  pub_foo = 1;
+  Foo = 1;
   bar = atom.foo + 2;
   baz = mod.bar + 4;
-  pub_f = std.set.filterMap;
-  pub_file = builtins.readFile "${mod}/bum";
-  pub_buzz = mod.buzz;
-  pub_next = ./next; # should be a non-existant path: /nix/store/next
-  pub_bar = mod.bar;
+  F = std.set.filterMap;
+  File = builtins.readFile "${mod}/bum";
+  Buzz = mod.buzz;
+  Next = ./next; # should be a non-existant path: /nix/store/next
+  Bar = mod.bar;
 }


### PR DESCRIPTION
It is much less verbose than a `pub_` prefix.

Semantics are:
```nix
{
  # declare: all capitalized outputs are public.
  MyFunc = x: x;

  # use: maintains nix's camel case convention
  some = mod.myFunc 1;
}
```