### PR TITLE
pkg_lib -> lib

### DIFF
--- a/src/atom/compose.nix
+++ b/src/atom/compose.nix
@@ -145,7 +145,7 @@ let
         }
       )
       {
-        _if = __isStd__ && l.elem "pkg_lib" __atom.features.resolved.atom;
+        _if = __isStd__ && l.elem "lib" __atom.features.resolved.atom;
         inherit (extern) lib;
       }
       {

--- a/src/dev.toml
+++ b/src/dev.toml
@@ -8,7 +8,7 @@ args = [{}]
 
 [compose.features]
 atom = ["std"]
-std = ["pkg_lib"]
+std = ["lib"]
 
 [backend.nix]
 # default when `eka` cli is ready

--- a/src/std.toml
+++ b/src/std.toml
@@ -22,5 +22,5 @@ fetcher = "npins"
 __is_std__ = true
 
 [features]
-pkg_lib = ["lib"]
+lib = []
 default = []

--- a/test/scope.toml
+++ b/test/scope.toml
@@ -5,7 +5,7 @@ sub = "lib"
 optional = true
 
 [features]
-pkg_lib = ["lib"]
+lib = []
 default = []
 
 [backends.nix]

--- a/test/std-import/import.nix
+++ b/test/std-import/import.nix
@@ -5,5 +5,5 @@ in
   default = f ./default.toml;
   noStd = f ./no-std.toml;
   explicit = f ./explicit.toml;
-  withNixpkgsLib = f ./pkglib.toml;
+  withLib = f ./with-lib.toml;
 }

--- a/test/std-import/import.sh
+++ b/test/std-import/import.sh
@@ -29,9 +29,9 @@ f="$(nix eval -f import.nix noStd.lib)"
 [[ "$f" == false ]]
 
 # no std set
-f="$(nix eval -f import.nix withNixpkgsLib.stdF)"
-[[ "$f" == '[ "lib" "pkg_lib" ]' ]]
-f="$(nix eval -f import.nix withNixpkgsLib.std)"
+f="$(nix eval -f import.nix withLib.stdF)"
+[[ "$f" == '[ "lib" ]' ]]
+f="$(nix eval -f import.nix withLib.std)"
 [[ "$f" == true ]]
-f="$(nix eval -f import.nix withNixpkgsLib.lib)"
+f="$(nix eval -f import.nix withLib.lib)"
 [[ "$f" == true ]]

--- a/test/std-import/with-lib.toml
+++ b/test/std-import/with-lib.toml
@@ -3,4 +3,4 @@ name = "test"
 path = "import"
 
 [compose.features]
-std = ["pkg_lib"]
+std = ["lib"]


### PR DESCRIPTION
# Context

- User has no or little prior context in Nixpkgs
- User may not understand that `pkg_lib` does not refer to the naive interpretation "a lib of a package"

# Solution

Just declare nixpkgs' lib as THE `lib` in the same way as it is attached to the namespace under `std.lib`, even if this obfuscates the actual distinction between a feature and an fetched input. If people make this mental shortcut, its overwhelmingly unconsequential: "I want  `lib`, I say `lib`, I get `lib`"