### PR TITLE
feat: trivial debug tracing information

### DIFF
--- a/src/core/compose.nix
+++ b/src/core/compose.nix
@@ -61,7 +61,6 @@ in
   config,
   extern ? { },
   features ? [ ],
-  debug ? false,
   # internal features of the composer function
   stdFeatures ? src.stdToml.features.default or [ ],
   coreFeatures ? src.coreToml.features.default,
@@ -91,11 +90,7 @@ let
     };
   };
 
-  debugMsg =
-    path:
-    "in ${config.atom.name}${if config.atom ? version then "-${config.atom.version}" else ""}${
-      if path == "" then "" else " at ${path}"
-    }";
+  msg = src.errors.debugMsg config;
 
   f =
     f: pre: dir:
@@ -171,7 +166,7 @@ let
               let
                 trace = src.errors.modPath par dir;
               in
-              src.errors.context debug (debugMsg "${trace}.${file.name}") member;
+              src.errors.context (msg "${trace}.${file.name}") member;
           }
         else
           null # Ignore other file types
@@ -191,7 +186,7 @@ let
           trace = src.errors.modPath par dir;
         in
         assert src.modIsValid module dir;
-        src.filterMap g contents // (src.errors.context debug (debugMsg trace) module);
+        src.filterMap g contents // (src.errors.context (msg trace) module);
 
     in
     if src.hasMod contents then

--- a/src/core/errors.nix
+++ b/src/core/errors.nix
@@ -19,9 +19,13 @@ in
 {
   inherit warn;
 
-  context =
-    debug: msg: value:
-    if debug then l.trace msg value else value;
+  debugMsg =
+    config: path:
+    "in ${config.atom.name}${if config.atom ? version then "-${config.atom.version}" else ""}${
+      if path == "" then "" else " at ${path}"
+    }";
+
+  context = msg: value: l.traceVerbose msg value;
   modPath =
     par: path:
     let


### PR DESCRIPTION
Resolves #28 #9

One of the best things about having a predictable module structure is that we can trivially construct location information. We can then use this to report unambiguously where we are in an Atom during evaluation.

This makes debugging trivial, since if you fail anywhere in your code the debug trace (when enabled) will print the last location visited inside the module system before the error occurred.

## Implementation

It was first attempted to use `builtins.addErrorContext` to print location information only in an error trace. However, this function only reports the context if the failure occurs immediately in the given value. If the error occurs later in a nested structure, then the call to `addErrorContext` is essentially useless and error information is never reported. Even if that weren't the case, we still wouldn't have control of where the message appears, and if there was a ton of library code in use, it may be too far up the trace to even be helpful.

So instead, in order to keep the implementation relatively simple while still being thorough, we simply use `builtins.trace`. We only trace where we are when `debug` is set to `true`, but when we do so, every module entry, and every module member entry is traced, with information about the atom you are in, version information (in case you have multiple versions of an atom), as well as the full path to the module or member.

This means that if an error occurs anywhere in the module system, the last trace message will be the full path to the module or member it occurred in. Making tracking down error locations in your code trivial compared to existing methods.

To make the power of this clear, here is the cli trace of a contrived error:
```
❯ nix-shell
trace: in dev-0.1.0
trace: in dev-0.1.0 at foo
trace: in dev-0.1.0 at foo.bar
trace: in dev-0.1.0 at foo.bar.shell
error:
<nix backtrace>
```

given this trace, and understanding atom's structure, we can trivially derive that shell is a module member, and we immediately know exactly which file contains the error, regardless of whether the nix backtrace is helpful or not.

## First Draft
This implementation serves as a draft to prove the value of the concept, but the format and details are up for ammendments.