### PR TITLE
Implement flake utility function `mkAtomicFlake`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,9 @@
 {
   description = "Composable Nix Modules";
+
   outputs = _: {
-    importAtom = import ./src/core/importAtom.nix;
     core = import ./src/core/mod.nix;
+    importAtom = import ./src/core/importAtom.nix;
+    mkAtomicFlake = import ./legacy-nix/mkAtomicFlake.nix;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  description = "Composable Nix Modules";
+  outputs = _: {
+    importAtom = import ./src/core/importAtom.nix;
+    core = import ./src/core/mod.nix;
+  };
+}

--- a/legacy-nix/mkAtomicFlake.nix
+++ b/legacy-nix/mkAtomicFlake.nix
@@ -1,0 +1,59 @@
+{
+  manifest,
+  noSystemManifest ? null,
+  perSystemNames ? [
+    "checks"
+    "packages"
+    "apps"
+    "formatter"
+    "devShells"
+    "hydraJobs"
+  ],
+  systems ? [
+    "x86_64-linux"
+    "aarch64-linux"
+    "x86_64-darwin"
+    "aarch64-darwin"
+  ],
+}:
+
+let
+  npinsSrcs = import ../src/npins;
+  lib = import (npinsSrcs."nixpkgs.lib" + "/lib");
+  l = lib // builtins;
+
+  importAtom = import ../src/core/importAtom.nix;
+
+  noSystemAtom = importAtom { } noSystemManifest;
+
+  verifyNoSystem =
+    atomManifest:
+    let
+      atomConfig = l.fromTOML (l.readFile atomManifest);
+      features = atomConfig.features.default or [ ];
+      hasSystemFeature = l.elem "system" features;
+    in
+    !hasSystemFeature;
+
+  hasNoSystemAtom = noSystemManifest != null && verifyNoSystem noSystemManifest;
+
+  optionalNoSystemAtom = if hasNoSystemAtom then noSystemAtom else { };
+
+  transformedAtomFromSystem =
+    system:
+    let
+      evaluatedAtom = importAtom { inherit system; } manifest;
+      # perSystemAtomAttributes = l.getAttrs perSystemNames evaluatedAtom;
+      mkPerSystemValue = _: value: { ${system} = value; };
+    in
+    l.mapAttrs mkPerSystemValue evaluatedAtom;
+
+  accumulate = accumulator: set: accumulator // set;
+  combineSets = _: sets: l.foldl' accumulate { } sets;
+
+  transformedAtoms = l.map transformedAtomFromSystem systems;
+
+  combinedPerSystemAttributes = l.zipAttrsWith combineSets transformedAtoms;
+
+in
+optionalNoSystemAtom // combinedPerSystemAttributes

--- a/src/core/compose.nix
+++ b/src/core/compose.nix
@@ -135,6 +135,10 @@ let
               std = l.removeAttrs (extern // atom) [ "std" ];
             }
             {
+              _if = !__isStd__;
+              use = l.removeAttrs extern [ "std" ];
+            }
+            {
               _if = __internal__test;
               # information about the internal module system itself
               # available to tests
@@ -197,7 +201,7 @@ let
       # Base case: no module
       { };
 
-  atomScope = l.removeAttrs (extern // atom // { inherit extern; }) [
+  atomScope = l.removeAttrs atom [
     "atom"
     (baseNameOf par)
   ];

--- a/src/core/errors.nix
+++ b/src/core/errors.nix
@@ -44,7 +44,8 @@ in
     modFromDir (stripParentDir par path);
   import = abort "Importing arbitrary Nix files is forbidden. Declare your dependencies via the module system instead.";
   fetch = abort "Ad hoc fetching is illegal. Declare dependencies statically in the manifest instead.";
-  system = abort "Accessing the current system is impure. Declare supported systems in the manifest.";
+  currentSystem = abort "Accessing the current system is impure. Declare system in the manifest.";
+  system = abort "`system` has been accessed and is undefined";
   time = _: warn "currentTime: Ignoring request for current time, returning: 0";
   nixPath = _: warn "nixPath: ignoring impure NIX_PATH request, returning: []";
   storePath = abort "Making explicit dependencies on store paths is illegal.";

--- a/src/core/importAtom.nix
+++ b/src/core/importAtom.nix
@@ -16,6 +16,7 @@
   valid input (and the CLI should type check on it's end)
 */
 {
+  system ? null,
   features ? null,
   __internal__test ? false,
 }:
@@ -109,11 +110,12 @@ let
 in
 mod.compose {
   inherit
+    src
+    root
+    config
+    system
     extern
     __internal__test
-    config
-    root
-    src
     ;
   features = features';
   coreFeatures =

--- a/src/core/importAtom.nix
+++ b/src/core/importAtom.nix
@@ -15,119 +15,149 @@
   revalidating on the Nix side as an extra precaution, but initially, we just assume we have a
   valid input (and the CLI should type check on it's end)
 */
-{
-  system ? null,
-  features ? null,
-  __internal__test ? false,
-}:
-path':
 let
-  mod = import ./mod.nix;
-
-  path = mod.prepDir path';
-
-  file = builtins.readFile path;
-  config = builtins.fromTOML file;
-  atom = config.atom or { };
-  id = builtins.seq version (atom.id or (mod.errors.missingAtom path' "id"));
-  version = atom.version or (mod.errors.missingAtom path' "version");
-
-  core = config.core or { };
-  std = config.std or { };
-
-  features' =
+  importAtom =
+    importAtomArgs@{
+      system ? null,
+      features ? null,
+      __internal__test ? false,
+    }:
+    path':
     let
-      featSet = config.features or { };
-      featIn = if features == null then featSet.default or [ ] else features;
-    in
-    mod.features.resolve featSet featIn;
+      mod = import ./mod.nix;
 
-  backend = config.backend or { };
-  nix = backend.nix or { };
+      path = mod.prepDir path';
+      root = mod.prepDir (dirOf path); # TODO Is prepDir required twice?
 
-  root = mod.prepDir (dirOf path);
+      file = builtins.readFile path;
+      config = builtins.fromTOML file;
+      atom = config.atom or { };
+      id = builtins.seq version (atom.id or (mod.errors.missingAtom path' "id"));
+      version = atom.version or (mod.errors.missingAtom path' "version");
+      core = config.core or { };
+      std = config.std or { };
+      meta = atom.meta or { };
 
-  src = builtins.seq id (
-    let
-      file = mod.parse (baseNameOf path);
-      len = builtins.stringLength file.name;
-    in
-    builtins.substring 0 (len - 1) file.name
-  );
-
-  extern =
-    let
-      # TODO native doesn't exist yet
-      fetcher = nix.fetcher or "native";
-      throwMissingNativeFetcher = abort "Native fetcher isn't implemented yet";
-
-      fetcherConfig = config.fetcher or { };
-      npinRoot = fetcherConfig.npin.root or "npins";
-      pins = import (dirOf path + "/${npinRoot}");
-
-      fetchEnabledNpinsDep =
-        depName: depConfig:
+      features =
         let
-          depIsEnabled =
-            (depConfig.optional or false && builtins.elem depName features') || (!depConfig.optional or false);
-
-          npinSrc = "${pins.${depConfig.name or depName}}/${depConfig.subdir or ""}";
-
-          applyArguments =
-            appliedFunction: nextArgument:
-            let
-              argsFromDeps = depConfig.argsFromDeps or true && builtins.isAttrs nextArgument;
-              argIntersectedwithDeps = nextArgument // (builtins.intersectAttrs nextArgument extern);
-            in
-            if argsFromDeps nextArgument then
-              appliedFunction argIntersectedwithDeps
-            else
-              appliedFunction nextArgument;
-
-          dependency =
-            if depConfig.import or false then
-              if depConfig.args or [ ] != [ ] then
-                builtins.foldl' applyArguments (import npinSrc) depConfig.args
-              else
-                import npinSrc
-            else
-              npinSrc;
+          atomFeatures = importAtomArgs.features or null;
+          featSet = config.features or { };
+          default = featSet.default or [ ];
+          argsHaveNoFeatures = atomFeatures == null;
+          featIn = if argsHaveNoFeatures then default else atomFeatures;
         in
-        if depIsEnabled then { "${depName}" = dependency; } else null;
+        mod.features.resolve featSet featIn;
 
-      npinsDeps = mod.filterMap fetchEnabledNpinsDep config.fetch or { };
+      backend = config.backend or { };
+      nix = backend.nix or { };
+
+      src = builtins.seq id (
+        let
+          file = mod.parse (baseNameOf path);
+          len = builtins.stringLength file.name;
+        in
+        builtins.substring 0 (len - 1) file.name
+      );
+
+      extern =
+        let
+          # TODO native doesn't exist yet
+          fetcher = nix.fetcher or "native";
+          throwMissingNativeFetcher = abort "Native fetcher isn't implemented yet";
+
+          fetcherConfig = config.fetcher or { };
+          npinRoot = fetcherConfig.npin.root or "npins";
+          pins = import (dirOf path + "/${npinRoot}");
+
+          local = config.local or { };
+
+          isDepEnabled =
+            depName: depConfig:
+            let
+              optional = depConfig.optional or false;
+              featureIsEnabled = builtins.elem depName features;
+            in
+            (optional && featureIsEnabled) || (!optional);
+
+          obtainLocalDep =
+            depName: depConfig:
+            let
+              depManifest = "${root}/${depConfig.path}";
+              depIsEnabled = isDepEnabled depName depConfig;
+              dependency = importAtom { inherit system; } depManifest;
+            in
+            if depIsEnabled then { "${depName}" = dependency; } else null;
+
+          obtainedLocalDeps = mod.filterMap obtainLocalDep local;
+
+          localDeps = if local != { } then obtainedLocalDeps else { };
+
+          fetchEnabledNpinsDep =
+            depName: depConfig:
+            let
+              importDep = depConfig.import or false;
+              depArgs = depConfig.args or [ ];
+              depHasArgs = depArgs != [ ];
+              depIsEnabled = isDepEnabled depName depConfig;
+
+              npinSrc = "${pins.${depConfig.name or depName}}/${depConfig.subdir or ""}";
+
+              applyArguments =
+                appliedFunction: nextArgument:
+                let
+                  argsFromDeps = depConfig.argsFromDeps or true && builtins.isAttrs nextArgument;
+                  argIntersectedwithDeps = nextArgument // (builtins.intersectAttrs nextArgument extern);
+                in
+                if argsFromDeps nextArgument then
+                  appliedFunction argIntersectedwithDeps
+                else
+                  appliedFunction nextArgument;
+
+              importedSrcWithArgs = builtins.foldl' applyArguments (import npinSrc) depArgs;
+
+              importedSrc = if depHasArgs then importedSrcWithArgs else import npinSrc;
+
+              dependency = if importDep then importedSrc else npinSrc;
+            in
+            if depIsEnabled then { "${depName}" = dependency; } else null;
+
+          npinsDeps = mod.filterMap fetchEnabledNpinsDep config.fetch or { };
+
+          externalDeps =
+            if fetcher == "npins" then
+              npinsDeps
+            else if fetcher == "native" then
+              throwMissingNativeFetcher
+            else
+              { };
+
+        in
+        localDeps // externalDeps;
 
     in
-    if fetcher == "npins" then
-      npinsDeps
-    else if fetcher == "native" then
-      throwMissingNativeFetcher
-    else
-      { };
+    mod.compose {
+      inherit
+        src
+        root
+        config
+        system
+        extern
+        features
+        __internal__test
+        ;
+      coreFeatures =
+        let
+          feat = core.features or mod.coreToml.features.default;
+        in
+        mod.features.resolve mod.coreToml.features feat;
+      stdFeatures =
+        let
+          feat = std.features or mod.stdToml.features.default;
+        in
+        mod.features.resolve mod.stdToml.features feat;
 
-  meta = atom.meta or { };
+      __isStd__ = meta.__is_std__ or false;
+    };
 
 in
-mod.compose {
-  inherit
-    src
-    root
-    config
-    system
-    extern
-    __internal__test
-    ;
-  features = features';
-  coreFeatures =
-    let
-      feat = core.features or mod.coreToml.features.default;
-    in
-    mod.features.resolve mod.coreToml.features feat;
-  stdFeatures =
-    let
-      feat = std.features or mod.stdToml.features.default;
-    in
-    mod.features.resolve mod.stdToml.features feat;
-
-  __isStd__ = meta.__is_std__ or false;
-}
+importAtom

--- a/src/dev/shell.nix
+++ b/src/dev/shell.nix
@@ -1,5 +1,5 @@
 {
-  pkgs ? atom.pkgs,
+  pkgs ? use.pkgs,
 }:
 pkgs.mkShell {
   packages = with pkgs; [


### PR DESCRIPTION
A function to use atoms to create flake outputs.
The following code can be found in a test repo here:
https://github.com/LiGoldragon/aidiyz/blob/f25e895fb9aa32d8ae30fece60845db42fedd34a/flake.nix#L1

``` nix
# flake.nix
{
  description = "An Atomic Flake";

  inputs.atom.url = "github:LiGoldragon/atom";

  outputs =
    inputs@{ self, atom, ... }:
    atom.mkAtomicFlake {
      manifest = ./. + "/simple@.toml";
      noSystemManifest = ./. + "/local-lib@.toml";
    };
}

```

``` toml
# simple@.toml
[atom]
id = "simple"
version = "0.1.0"

[local.local-lib]
path = "local-lib@.toml"

[fetch.nixpkgs]
name = "nixpkgs"
import = true

[features]
default = ["system"]

[backend.nix]
fetcher = "npins"
```

``` nix
# simple/mod.nix
let
  pkgs = use.nixpkgs {
    inherit system;
  };

  mkStringPackage =
    string:
    pkgs.runCommand string { } ''
      mkdir $out
      echo ${string} > $out/string.txt
    '';

in
{
  Packages.default = pkgs.hello;
  Packages.simpleString = mkStringPackage use.local-lib.simpleString;
  Packages.hashString = mkStringPackage use.local-lib.stringHash;

}
```

``` toml
# local-lib@.toml
[atom]
id = "local-lib"
version = "0.1.0"
```

``` nix
# local-lib/mod.nix
{
  SimpleString = "A simple string";
  StringHash = std.hashString "sha256" mod.simpleString;
}
```